### PR TITLE
Fix connection-slot leak when rejected clients have sent data

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -11,7 +11,7 @@ const LOG_LEVELS = {
   error: 3,
 };
 
-const currentLevel = LOG_LEVELS[config.logLevel] || LOG_LEVELS.info;
+const currentLevel = LOG_LEVELS[config.logLevel] ?? LOG_LEVELS.info;
 
 function log(level, message, data = null) {
   if (LOG_LEVELS[level] >= currentLevel) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "node server.js",
+    "test": "node --test tests/",
     "setup-geoip": "node download-geoip.js"
   },
   "dependencies": {

--- a/proxy.js
+++ b/proxy.js
@@ -38,10 +38,12 @@ class ProxyConnection {
       this.clientSocket.on('error', (err) => {
         logger.debug(`[${this.connectionId}] Client socket error during rejection: ${err.message}`);
       });
-      this.clientSocket.end();
+      // destroy() (not end()): rejected sockets have no data handler, so if the
+      // client already sent bytes, end() never completes and 'close' never fires
+      this.clientSocket.destroy();
       return;
     }
-    
+
     logger.info(`[${this.connectionId}] New connection from ${this.clientAddress}`);
     
     // Check IP filter (whitelist, blocklist, and rate limiting)
@@ -56,7 +58,7 @@ class ProxyConnection {
         this.clientSocket.on('error', (err) => {
           logger.debug(`[${this.connectionId}] Client socket error during rejection: ${err.message}`);
         });
-        this.clientSocket.end();
+        this.clientSocket.destroy();
         return;
       }
       isWhitelisted = filterResult.whitelisted || false;
@@ -69,10 +71,10 @@ class ProxyConnection {
       this.clientSocket.on('error', (err) => {
         logger.debug(`[${this.connectionId}] Client socket error during rejection: ${err.message}`);
       });
-      this.clientSocket.end();
+      this.clientSocket.destroy();
       return;
     }
-    
+
     // Disable Nagle's algorithm for better real-time performance
     this.clientSocket.setNoDelay(true);
     this.clientSocket.setKeepAlive(true);

--- a/server.js
+++ b/server.js
@@ -85,7 +85,8 @@ class BBSFirewall {
     // Check max connections limit
     if (this.activeConnections >= config.maxConnections) {
       logger.warn(`Connection rejected: max connections (${config.maxConnections}) reached`);
-      clientSocket.end();
+      clientSocket.on('error', () => {});
+      clientSocket.destroy();
       return;
     }
 

--- a/tests/rejection-leak.test.js
+++ b/tests/rejection-leak.test.js
@@ -13,10 +13,26 @@ const { spawn, spawnSync } = require('child_process');
 
 const REPO_ROOT = path.join(__dirname, '..');
 
-function listen(server, port, host) {
+// Reserve an ephemeral port by binding to 0 and releasing it
+// (the config validator does not accept LISTEN_PORT=0 directly)
+function getFreePort() {
   return new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(port, host, () => resolve(server.address().port));
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen(0, () => {
+      const port = srv.address().port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function ipv6LoopbackAvailable() {
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.once('error', () => resolve(false));
+    srv.listen(0, '::1', () => {
+      srv.close(() => resolve(true));
+    });
   });
 }
 
@@ -43,17 +59,27 @@ function firstData(sock, timeoutMs) {
 }
 
 test('a rejected connection does not leak the active-connection slot', async (t) => {
+  // The "allowed" client connects via IPv6 loopback so the IPv4 loopback can
+  // be blocklisted (127.0.0.x aliases are not bindable by default on macOS)
+  if (!(await ipv6LoopbackAvailable())) {
+    t.skip('IPv6 loopback (::1) not available');
+    return;
+  }
+
   // Fake backend so the test never touches a real BBS
   const backend = net.createServer((sock) => {
     sock.write('HELLO-BACKEND');
   });
-  const backendPort = await listen(backend, 0, '127.0.0.1');
+  const backendPort = await new Promise((resolve, reject) => {
+    backend.once('error', reject);
+    backend.listen(0, '127.0.0.1', () => resolve(backend.address().port));
+  });
 
   // Blocklist IPv4 loopback; the "allowed" client will come in via ::1
   const blocklistPath = path.join(os.tmpdir(), `bbsfw-test-blocklist-${process.pid}.txt`);
   fs.writeFileSync(blocklistPath, '127.0.0.1\n');
 
-  const listenPort = 20000 + Math.floor(Math.random() * 20000);
+  const listenPort = await getFreePort();
   const child = spawn(process.execPath, ['server.js'], {
     cwd: REPO_ROOT,
     env: {
@@ -70,8 +96,11 @@ test('a rejected connection does not leak the active-connection slot', async (t)
     },
   });
 
-  t.after(() => {
+  t.after(async () => {
+    // SIGKILL on purpose: the graceful-shutdown handler can wait up to 10s
+    const exited = new Promise((r) => child.once('exit', r));
     child.kill('SIGKILL');
+    await exited;
     backend.close();
     fs.rmSync(blocklistPath, { force: true });
   });
@@ -86,6 +115,9 @@ test('a rejected connection does not leak the active-connection slot', async (t)
         resolve();
       }
     });
+    child.stderr.on('data', (d) => {
+      out += d.toString();
+    });
     child.on('exit', (code) => reject(new Error(`server exited (${code}):\n${out}`)));
   });
 
@@ -93,11 +125,15 @@ test('a rejected connection does not leak the active-connection slot', async (t)
   // (like a telnet client's IAC negotiation) and stays connected, leaving
   // unread data pending when the proxy rejects it.
   const blocked = await connect(listenPort, '127.0.0.1');
+  blocked.on('error', () => {});
   blocked.write('\xff\xfd\x18');
   t.after(() => blocked.destroy());
 
-  // Give the server time to reject the blocked client and release its slot
-  await new Promise((r) => setTimeout(r, 500));
+  // The observable effect of the rejection is the server closing the blocked
+  // socket; wait for that rather than a fixed sleep
+  await new Promise((resolve) => blocked.once('close', resolve));
+  // Small settle so the server-side 'close' handler (slot release) runs
+  await new Promise((r) => setTimeout(r, 100));
 
   // Allowed client: must get the only connection slot and reach the backend
   const allowed = await connect(listenPort, '::1');

--- a/tests/rejection-leak.test.js
+++ b/tests/rejection-leak.test.js
@@ -1,0 +1,120 @@
+/**
+ * Regression tests for connection-slot leak on rejected connections
+ * and for LOG_LEVEL=debug being honored.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const net = require('net');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn, spawnSync } = require('child_process');
+
+const REPO_ROOT = path.join(__dirname, '..');
+
+function listen(server, port, host) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, () => resolve(server.address().port));
+  });
+}
+
+function connect(port, host) {
+  return new Promise((resolve, reject) => {
+    const sock = net.createConnection({ port, host }, () => resolve(sock));
+    sock.once('error', reject);
+  });
+}
+
+// Waits for data (resolves) or close-without-data (resolves with null)
+function firstData(sock, timeoutMs) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(null), timeoutMs);
+    sock.once('data', (d) => {
+      clearTimeout(timer);
+      resolve(d);
+    });
+    sock.once('close', () => {
+      clearTimeout(timer);
+      resolve(null);
+    });
+  });
+}
+
+test('a rejected connection does not leak the active-connection slot', async (t) => {
+  // Fake backend so the test never touches a real BBS
+  const backend = net.createServer((sock) => {
+    sock.write('HELLO-BACKEND');
+  });
+  const backendPort = await listen(backend, 0, '127.0.0.1');
+
+  // Blocklist IPv4 loopback; the "allowed" client will come in via ::1
+  const blocklistPath = path.join(os.tmpdir(), `bbsfw-test-blocklist-${process.pid}.txt`);
+  fs.writeFileSync(blocklistPath, '127.0.0.1\n');
+
+  const listenPort = 20000 + Math.floor(Math.random() * 20000);
+  const child = spawn(process.execPath, ['server.js'], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      LISTEN_PORT: String(listenPort),
+      BACKEND_HOST: '127.0.0.1',
+      BACKEND_PORT: String(backendPort),
+      MAX_CONNECTIONS: '1',
+      BLOCKED_COUNTRIES: '',
+      RATE_LIMIT_ENABLED: 'false',
+      BLOCKLIST_PATH: blocklistPath,
+      SSH_ENABLED: 'false',
+      LOG_LEVEL: 'info',
+    },
+  });
+
+  t.after(() => {
+    child.kill('SIGKILL');
+    backend.close();
+    fs.rmSync(blocklistPath, { force: true });
+  });
+
+  await new Promise((resolve, reject) => {
+    let out = '';
+    const timer = setTimeout(() => reject(new Error(`server never started:\n${out}`)), 5000);
+    child.stdout.on('data', (d) => {
+      out += d.toString();
+      if (out.includes('listening on port')) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.on('exit', (code) => reject(new Error(`server exited (${code}):\n${out}`)));
+  });
+
+  // Blocked client: connects from the blocklisted IP, immediately sends bytes
+  // (like a telnet client's IAC negotiation) and stays connected, leaving
+  // unread data pending when the proxy rejects it.
+  const blocked = await connect(listenPort, '127.0.0.1');
+  blocked.write('\xff\xfd\x18');
+  t.after(() => blocked.destroy());
+
+  // Give the server time to reject the blocked client and release its slot
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Allowed client: must get the only connection slot and reach the backend
+  const allowed = await connect(listenPort, '::1');
+  t.after(() => allowed.destroy());
+  const data = await firstData(allowed, 2000);
+
+  assert.ok(
+    data && data.toString().includes('HELLO-BACKEND'),
+    'allowed connection should reach the backend; got no data — the rejected connection leaked the slot'
+  );
+});
+
+test('LOG_LEVEL=debug enables debug logging', () => {
+  const result = spawnSync(
+    process.execPath,
+    ['-e', "require('./logger').debug('dbg-probe-message')"],
+    { cwd: REPO_ROOT, env: { ...process.env, LOG_LEVEL: 'debug' }, encoding: 'utf8' }
+  );
+  assert.match(result.stdout, /dbg-probe-message/, 'debug message should be printed when LOG_LEVEL=debug');
+});


### PR DESCRIPTION
## The bug

The rejection paths (IP filter, country block, undefined remote address, max connections) call `clientSocket.end()` on sockets that never get a `data` handler attached. If the client has already sent bytes — and telnet clients send IAC negotiation immediately on connect — the socket's readable side is never consumed, so it never finishes closing and `'close'` never fires.

`activeConnections` is decremented in that `'close'` handler, so each such rejection permanently leaks a connection slot (and the socket fd, which lingers in TCP `CLOSED` state) until `CONNECTION_TIMEOUT` destroys the socket — 5 minutes by default.

With a low `MAX_CONNECTIONS`, one rejection bricks the proxy: every subsequent caller is rejected with "max connections reached" until the timeout fires. It's easy to trigger accidentally — connecting ~11 times in a minute trips the default rate limiter, and that rejection is exactly the path that leaks.

## Repro

1. `MAX_CONNECTIONS=1`, any rejection rule active (e.g. an IP in the blocklist)
2. Connect from a rejected client that sends bytes on connect (any telnet client)
3. Connect from an allowed client → rejected with "max connections (1) reached" even though zero sessions are active

## The fix

- Use `destroy()` instead of `end()` in all four rejection paths — `'close'` is then guaranteed to fire, releasing the slot and the fd.
- Attach an error handler in the max-connections rejection path, where a socket `'error'` event previously had no listener and would have crashed the process.
- Also fixes `LOG_LEVEL=debug` never taking effect: the debug level maps to `0`, which is falsy, so `|| LOG_LEVELS.info` always fell back to info (`??` now).

## Tests

Adds a `node:test` suite (`npm test`, no new dependencies):
- black-box leak regression test (spawns the real server against a fake backend, rejects a client that sent bytes, asserts the next caller still gets through)
- `LOG_LEVEL=debug` produces debug output