### PR TITLE
Fix connection-slot leak on rejected connections; add post-session grace period

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Configure the firewall by setting environment variables or editing `.env`:
 | `BACKEND_PORT_UTF8` | Backend port for UTF-8 (Unicode) clients | `2423` |
 | `MAX_CONNECTIONS` | Maximum simultaneous connections | `100` |
 | `CONNECTION_TIMEOUT` | Connection timeout in milliseconds (0 to disable) | `300000` (5 min) |
+| `POST_SESSION_GRACE_MS` | Hold new callers this long after the previous session ends, so a single-line backend (e.g. a real C64 BBS) can recycle. Bytes sent while held are buffered and forwarded. (0 to disable) | `0` |
 | `SSH_ENABLED` | Enable SSH server | `false` |
 | `SSH_LISTEN_PORT` | Port to listen on for incoming SSH connections | `2222` |
 | `SSH_HOST_KEY` | Path to SSH host private key file | `./ssh_host_key` |

--- a/config.js
+++ b/config.js
@@ -21,6 +21,10 @@ const config = {
   // Server settings
   maxConnections: parseInt(process.env.MAX_CONNECTIONS || '100', 10),
   connectionTimeout: parseInt(process.env.CONNECTION_TIMEOUT || '300000', 10), // 5 minutes default
+
+  // Hold new callers this long after the previous session ends, so a
+  // single-line backend (e.g. a real C64 BBS) has time to recycle. 0 = off.
+  postSessionGraceMs: parseInt(process.env.POST_SESSION_GRACE_MS || '0', 10),
   
   // Country blocking (comma-separated ISO 3166-1 alpha-2 country codes)
   // Example: BLOCKED_COUNTRIES=CN,RU,KP

--- a/docs/superpowers/specs/2026-06-11-post-session-grace-period-design.md
+++ b/docs/superpowers/specs/2026-06-11-post-session-grace-period-design.md
@@ -1,0 +1,68 @@
+# Post-session grace period — design
+
+**Date:** 2026-06-11
+**Status:** Approved (design discussed and accepted in session)
+
+## Problem
+
+The backend is turbo64, a single-line BBS running on real C64 hardware (Ultimate 64
+modem emulation at 192.168.1.202:3000). After a caller disconnects, the BBS takes a few
+seconds to recycle (`net_disconnect` → ACIA settle → WFC redraw). The U64 still accepts
+TCP during that window, so a caller who reconnects quickly either gets no banner or is
+dropped by the hangup intended for the previous caller.
+
+## Solution
+
+When a new connection arrives within `POST_SESSION_GRACE_MS` of the previous session
+ending, bbsfw accepts the caller and silently holds the connection until the grace
+window has elapsed, then connects to the backend as normal.
+
+### Config (config.js)
+
+- `postSessionGraceMs` from env `POST_SESSION_GRACE_MS`, default `0` = disabled.
+  With the default, no new code path executes — current behavior is unchanged.
+- Deployment .env gets `POST_SESSION_GRACE_MS=5000`.
+
+### Session-end tracking (proxy.js)
+
+- Module-level `lastSessionEndMs` timestamp, initially `0`.
+- `ProxyConnection` sets `this.backendConnected = true` in the backend connect callback.
+- `cleanup()` updates `lastSessionEndMs = Date.now()` only when `backendConnected` is
+  true. Rejected callers and failed backend connects never arm the grace period; only a
+  session that actually reached the BBS does.
+
+### Hold logic (proxy.js connect())
+
+After the IP/country filter checks pass:
+
+1. `wait = postSessionGraceMs - (Date.now() - lastSessionEndMs)`.
+2. If `wait <= 0`: connect to the backend immediately (current behavior).
+3. If `wait > 0`:
+   - Log at info level that the caller is held for `wait` ms (backend recycle grace).
+   - Buffer client bytes that arrive during the hold (telnet clients send IAC
+     negotiation immediately; dropping those bytes would break turbo64's terminal
+     detection). Buffered bytes are flushed to the backend, in order, before any other
+     client data once connected.
+   - On timer expiry: connect to the backend, flush buffer, proceed as normal.
+   - If the caller disconnects mid-hold: cancel the timer, never connect to the
+     backend, clean up normally (slot is freed, grace period is not re-armed).
+4. A held caller occupies a connection slot. With `MAX_CONNECTIONS=1` this keeps the
+   line busy for later callers, which is correct for a single-line BBS.
+
+### Out of scope
+
+- The SSH path (ssh.js) has separate backend-connect code and is disabled in this
+  deployment; it does not get the grace period.
+- No "please wait" message to the held caller — a short silent pause is normal BBS
+  behavior, and injecting bytes could confuse telnet negotiation.
+
+## Testing
+
+Extend `tests/` (node:test, black-box: spawned server + fake backend):
+
+1. With `POST_SESSION_GRACE_MS=1500`: caller A connects, receives backend data,
+   disconnects. Caller B connects immediately after, sends bytes during the hold.
+   Assert: B receives backend data no sooner than ~1.2 s after connecting, and the
+   bytes B sent during the hold arrive at the fake backend in order.
+2. Disabled path (`POST_SESSION_GRACE_MS` unset/0) is covered by the existing tests,
+   which assert an immediate backend connection.

--- a/logger.js
+++ b/logger.js
@@ -11,7 +11,7 @@ const LOG_LEVELS = {
   error: 3,
 };
 
-const currentLevel = LOG_LEVELS[config.logLevel] || LOG_LEVELS.info;
+const currentLevel = LOG_LEVELS[config.logLevel] ?? LOG_LEVELS.info;
 
 function log(level, message, data = null) {
   if (LOG_LEVELS[level] >= currentLevel) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "node server.js",
+    "test": "node --test tests/",
     "setup-geoip": "node download-geoip.js"
   },
   "dependencies": {

--- a/proxy.js
+++ b/proxy.js
@@ -9,6 +9,11 @@ const { getGeoIP } = require('./geoip');
 const { getIPFilter } = require('./ipfilter');
 const { detectFromTelnetNegotiation, getBackendPortForEncoding } = require('./encoding-detector');
 
+// When the last proxied session ended. Used for the post-session grace period:
+// a single-line backend (real C64 hardware) needs a few seconds to recycle
+// after a caller disconnects before it can answer the next one.
+let lastSessionEndMs = 0;
+
 class ProxyConnection {
   constructor(clientSocket, backendHost, backendPort) {
     this.clientSocket = clientSocket;
@@ -22,6 +27,11 @@ class ProxyConnection {
     this.isCleanedUp = false;
     this.detectedEncoding = 'cp437'; // Default encoding
     this.terminalType = null;
+    this.backendConnected = false;
+    this.graceTimer = null;
+    this.graceBuffer = null;
+    this.graceDataHandler = null;
+    this.clientHandlersAttached = false;
   }
 
   generateConnectionId() {
@@ -38,7 +48,9 @@ class ProxyConnection {
       this.clientSocket.on('error', (err) => {
         logger.debug(`[${this.connectionId}] Client socket error during rejection: ${err.message}`);
       });
-      this.clientSocket.end();
+      // destroy() (not end()): rejected sockets have no data handler, so if the
+      // client already sent bytes, end() never completes and 'close' never fires
+      this.clientSocket.destroy();
       return;
     }
     
@@ -56,7 +68,7 @@ class ProxyConnection {
         this.clientSocket.on('error', (err) => {
           logger.debug(`[${this.connectionId}] Client socket error during rejection: ${err.message}`);
         });
-        this.clientSocket.end();
+        this.clientSocket.destroy();
         return;
       }
       isWhitelisted = filterResult.whitelisted || false;
@@ -69,14 +81,59 @@ class ProxyConnection {
       this.clientSocket.on('error', (err) => {
         logger.debug(`[${this.connectionId}] Client socket error during rejection: ${err.message}`);
       });
-      this.clientSocket.end();
+      this.clientSocket.destroy();
       return;
     }
     
     // Disable Nagle's algorithm for better real-time performance
     this.clientSocket.setNoDelay(true);
     this.clientSocket.setKeepAlive(true);
-    
+
+    // Post-session grace period: hold the caller until the backend has had
+    // time to recycle after the previous session
+    const graceRemaining = config.postSessionGraceMs > 0
+      ? config.postSessionGraceMs - (Date.now() - lastSessionEndMs)
+      : 0;
+
+    if (graceRemaining > 0) {
+      this.holdForGracePeriod(graceRemaining);
+      return;
+    }
+
+    this.connectToBackend();
+  }
+
+  holdForGracePeriod(waitMs) {
+    logger.info(`[${this.connectionId}] Holding connection for ${waitMs}ms (post-session grace, backend recycling)`);
+    this.clientHandlersAttached = true;
+
+    // Buffer client bytes (e.g. telnet IAC negotiation) sent while held, so
+    // they reach the backend in order once connected
+    this.graceBuffer = [];
+    this.graceDataHandler = (data) => {
+      this.graceBuffer.push(data);
+    };
+    this.clientSocket.on('data', this.graceDataHandler);
+
+    this.clientSocket.on('error', (err) => {
+      logger.error(`[${this.connectionId}] Client socket error: ${err.message}`);
+      this.cleanup('client-error');
+    });
+    this.clientSocket.on('close', (hadError) => {
+      logger.debug(`[${this.connectionId}] Client socket closed during grace hold (hadError: ${hadError})`);
+      this.cleanup('client-close');
+    });
+
+    this.graceTimer = setTimeout(() => {
+      this.graceTimer = null;
+      if (this.isCleanedUp) {
+        return;
+      }
+      this.connectToBackend();
+    }, waitMs);
+  }
+
+  connectToBackend() {
     // Determine backend port based on encoding (if detection is enabled)
     const actualBackendPort = config.encodingDetection 
       ? getBackendPortForEncoding(this.detectedEncoding, config)
@@ -94,10 +151,25 @@ class ProxyConnection {
       const backendAddr = `${this.backendSocket.remoteAddress}:${this.backendSocket.remotePort}`;
       const localAddr = `${this.backendSocket.localAddress}:${this.backendSocket.localPort}`;
       logger.info(`[${this.connectionId}] Connected to backend ${backendAddr} (from ${localAddr})`);
+      this.backendConnected = true;
       // Disable Nagle's algorithm on backend socket too
       this.backendSocket.setNoDelay(true);
       this.backendSocket.setKeepAlive(true);
     });
+
+    // Forward bytes the client sent while held for the grace period (Node
+    // queues writes made before the backend connection completes)
+    if (this.graceDataHandler) {
+      this.clientSocket.removeListener('data', this.graceDataHandler);
+      this.graceDataHandler = null;
+    }
+    if (this.graceBuffer) {
+      for (const chunk of this.graceBuffer) {
+        this.bytesFromClient += chunk.length;
+        this.backendSocket.write(chunk);
+      }
+      this.graceBuffer = null;
+    }
 
     // Setup error handlers BEFORE other handlers to catch connection errors
     this.setupErrorHandlers();
@@ -181,10 +253,13 @@ class ProxyConnection {
   }
 
   setupErrorHandlers() {
-    this.clientSocket.on('error', (err) => {
-      logger.error(`[${this.connectionId}] Client socket error: ${err.message}`);
-      this.cleanup('client-error');
-    });
+    // Held connections already have client error/close handlers attached
+    if (!this.clientHandlersAttached) {
+      this.clientSocket.on('error', (err) => {
+        logger.error(`[${this.connectionId}] Client socket error: ${err.message}`);
+        this.cleanup('client-error');
+      });
+    }
 
     this.backendSocket.on('error', (err) => {
       logger.error(`[${this.connectionId}] Backend socket error: ${err.message}`);
@@ -193,10 +268,12 @@ class ProxyConnection {
   }
 
   setupCloseHandlers() {
-    this.clientSocket.on('close', (hadError) => {
-      logger.debug(`[${this.connectionId}] Client socket closed (hadError: ${hadError})`);
-      this.cleanup('client-close');
-    });
+    if (!this.clientHandlersAttached) {
+      this.clientSocket.on('close', (hadError) => {
+        logger.debug(`[${this.connectionId}] Client socket closed (hadError: ${hadError})`);
+        this.cleanup('client-close');
+      });
+    }
 
     this.backendSocket.on('close', (hadError) => {
       logger.debug(`[${this.connectionId}] Backend socket closed (hadError: ${hadError})`);
@@ -209,7 +286,17 @@ class ProxyConnection {
       return; // Prevent duplicate cleanup
     }
     this.isCleanedUp = true;
-    
+
+    if (this.graceTimer) {
+      clearTimeout(this.graceTimer);
+      this.graceTimer = null;
+    }
+
+    // Only a session that actually reached the backend arms the grace period
+    if (this.backendConnected) {
+      lastSessionEndMs = Date.now();
+    }
+
     logger.info(`[${this.connectionId}] Connection closed (reason: ${reason}). Bytes: client→backend=${this.bytesFromClient}, backend→client=${this.bytesFromBackend}`);
     
     if (this.clientSocket && !this.clientSocket.destroyed) {

--- a/server.js
+++ b/server.js
@@ -85,7 +85,8 @@ class BBSFirewall {
     // Check max connections limit
     if (this.activeConnections >= config.maxConnections) {
       logger.warn(`Connection rejected: max connections (${config.maxConnections}) reached`);
-      clientSocket.end();
+      clientSocket.on('error', () => {});
+      clientSocket.destroy();
       return;
     }
 

--- a/tests/grace-period.test.js
+++ b/tests/grace-period.test.js
@@ -14,6 +14,19 @@ const REPO_ROOT = path.join(__dirname, '..');
 
 const GRACE_MS = 1500;
 
+// Reserve an ephemeral port by binding to 0 and releasing it
+// (the config validator does not accept LISTEN_PORT=0 directly)
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen(0, () => {
+      const port = srv.address().port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
 function connect(port, host) {
   return new Promise((resolve, reject) => {
     const sock = net.createConnection({ port, host }, () => resolve(sock));
@@ -53,7 +66,7 @@ test('reconnect after a session is held for the grace period, with client bytes 
     backend.listen(0, '127.0.0.1', () => resolve(backend.address().port));
   });
 
-  const listenPort = 20000 + Math.floor(Math.random() * 20000);
+  const listenPort = await getFreePort();
   const child = spawn(process.execPath, ['server.js'], {
     cwd: REPO_ROOT,
     env: {
@@ -71,8 +84,11 @@ test('reconnect after a session is held for the grace period, with client bytes 
     },
   });
 
-  t.after(() => {
+  t.after(async () => {
+    // SIGKILL on purpose: the graceful-shutdown handler can wait up to 10s
+    const exited = new Promise((r) => child.once('exit', r));
     child.kill('SIGKILL');
+    await exited;
     backend.close();
   });
 
@@ -85,6 +101,9 @@ test('reconnect after a session is held for the grace period, with client bytes 
         clearTimeout(timer);
         resolve();
       }
+    });
+    child.stderr.on('data', (d) => {
+      out += d.toString();
     });
     child.on('exit', (code) => reject(new Error(`server exited (${code}):\n${out}`)));
   });

--- a/tests/grace-period.test.js
+++ b/tests/grace-period.test.js
@@ -1,0 +1,123 @@
+/**
+ * Post-session grace period: after a session ends, a quick reconnect is held
+ * until POST_SESSION_GRACE_MS has elapsed, with client bytes sent during the
+ * hold buffered and flushed to the backend in order.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const net = require('net');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const REPO_ROOT = path.join(__dirname, '..');
+
+const GRACE_MS = 1500;
+
+function connect(port, host) {
+  return new Promise((resolve, reject) => {
+    const sock = net.createConnection({ port, host }, () => resolve(sock));
+    sock.once('error', reject);
+  });
+}
+
+function firstData(sock, timeoutMs) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(null), timeoutMs);
+    sock.once('data', (d) => {
+      clearTimeout(timer);
+      resolve(d);
+    });
+    sock.once('close', () => {
+      clearTimeout(timer);
+      resolve(null);
+    });
+  });
+}
+
+function delay(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+test('reconnect after a session is held for the grace period, with client bytes buffered', async (t) => {
+  // Fake backend: greets each caller and records what it receives
+  const backendReceived = [];
+  const backend = net.createServer((sock) => {
+    const chunks = [];
+    backendReceived.push(chunks);
+    sock.on('data', (d) => chunks.push(d));
+    sock.write('HELLO-BACKEND');
+  });
+  const backendPort = await new Promise((resolve, reject) => {
+    backend.once('error', reject);
+    backend.listen(0, '127.0.0.1', () => resolve(backend.address().port));
+  });
+
+  const listenPort = 20000 + Math.floor(Math.random() * 20000);
+  const child = spawn(process.execPath, ['server.js'], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      LISTEN_PORT: String(listenPort),
+      BACKEND_HOST: '127.0.0.1',
+      BACKEND_PORT: String(backendPort),
+      MAX_CONNECTIONS: '1',
+      BLOCKED_COUNTRIES: '',
+      RATE_LIMIT_ENABLED: 'false',
+      BLOCKLIST_PATH: '',
+      SSH_ENABLED: 'false',
+      LOG_LEVEL: 'info',
+      POST_SESSION_GRACE_MS: String(GRACE_MS),
+    },
+  });
+
+  t.after(() => {
+    child.kill('SIGKILL');
+    backend.close();
+  });
+
+  await new Promise((resolve, reject) => {
+    let out = '';
+    const timer = setTimeout(() => reject(new Error(`server never started:\n${out}`)), 5000);
+    child.stdout.on('data', (d) => {
+      out += d.toString();
+      if (out.includes('listening on port')) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.on('exit', (code) => reject(new Error(`server exited (${code}):\n${out}`)));
+  });
+
+  // Caller A: full session — must NOT be delayed (no prior session)
+  const a = await connect(listenPort, '127.0.0.1');
+  const aStart = Date.now();
+  const aData = await firstData(a, 3000);
+  assert.ok(aData && aData.toString().includes('HELLO-BACKEND'), 'caller A should reach the backend');
+  assert.ok(Date.now() - aStart < 1000, 'caller A (no prior session) should connect without delay');
+  a.destroy();
+
+  // Give the server a moment to process A's disconnect (arms the grace period)
+  await delay(150);
+
+  // Caller B: reconnects within the grace window, sends bytes while held
+  const b = await connect(listenPort, '127.0.0.1');
+  const bStart = Date.now();
+  b.write('AB');
+  b.write('CD');
+  const bData = await firstData(b, GRACE_MS + 3000);
+  const bElapsed = Date.now() - bStart;
+  t.after(() => b.destroy());
+
+  assert.ok(bData && bData.toString().includes('HELLO-BACKEND'), 'caller B should eventually reach the backend');
+  assert.ok(
+    bElapsed >= GRACE_MS - 400,
+    `caller B should be held for the remaining grace period (got backend data after ${bElapsed}ms)`
+  );
+
+  // Bytes sent during the hold must arrive at the backend, in order
+  await delay(200);
+  assert.strictEqual(backendReceived.length, 2, 'backend should have seen exactly two sessions');
+  const bToBackend = Buffer.concat(backendReceived[1]).toString();
+  assert.ok(bToBackend.startsWith('ABCD'), `bytes sent during hold should reach backend in order (got: ${JSON.stringify(bToBackend)})`);
+});

--- a/tests/rejection-leak.test.js
+++ b/tests/rejection-leak.test.js
@@ -13,10 +13,26 @@ const { spawn, spawnSync } = require('child_process');
 
 const REPO_ROOT = path.join(__dirname, '..');
 
-function listen(server, port, host) {
+// Reserve an ephemeral port by binding to 0 and releasing it
+// (the config validator does not accept LISTEN_PORT=0 directly)
+function getFreePort() {
   return new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(port, host, () => resolve(server.address().port));
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen(0, () => {
+      const port = srv.address().port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function ipv6LoopbackAvailable() {
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.once('error', () => resolve(false));
+    srv.listen(0, '::1', () => {
+      srv.close(() => resolve(true));
+    });
   });
 }
 
@@ -43,17 +59,27 @@ function firstData(sock, timeoutMs) {
 }
 
 test('a rejected connection does not leak the active-connection slot', async (t) => {
+  // The "allowed" client connects via IPv6 loopback so the IPv4 loopback can
+  // be blocklisted (127.0.0.x aliases are not bindable by default on macOS)
+  if (!(await ipv6LoopbackAvailable())) {
+    t.skip('IPv6 loopback (::1) not available');
+    return;
+  }
+
   // Fake backend so the test never touches a real BBS
   const backend = net.createServer((sock) => {
     sock.write('HELLO-BACKEND');
   });
-  const backendPort = await listen(backend, 0, '127.0.0.1');
+  const backendPort = await new Promise((resolve, reject) => {
+    backend.once('error', reject);
+    backend.listen(0, '127.0.0.1', () => resolve(backend.address().port));
+  });
 
   // Blocklist IPv4 loopback; the "allowed" client will come in via ::1
   const blocklistPath = path.join(os.tmpdir(), `bbsfw-test-blocklist-${process.pid}.txt`);
   fs.writeFileSync(blocklistPath, '127.0.0.1\n');
 
-  const listenPort = 20000 + Math.floor(Math.random() * 20000);
+  const listenPort = await getFreePort();
   const child = spawn(process.execPath, ['server.js'], {
     cwd: REPO_ROOT,
     env: {
@@ -70,8 +96,11 @@ test('a rejected connection does not leak the active-connection slot', async (t)
     },
   });
 
-  t.after(() => {
+  t.after(async () => {
+    // SIGKILL on purpose: the graceful-shutdown handler can wait up to 10s
+    const exited = new Promise((r) => child.once('exit', r));
     child.kill('SIGKILL');
+    await exited;
     backend.close();
     fs.rmSync(blocklistPath, { force: true });
   });
@@ -86,6 +115,9 @@ test('a rejected connection does not leak the active-connection slot', async (t)
         resolve();
       }
     });
+    child.stderr.on('data', (d) => {
+      out += d.toString();
+    });
     child.on('exit', (code) => reject(new Error(`server exited (${code}):\n${out}`)));
   });
 
@@ -93,11 +125,15 @@ test('a rejected connection does not leak the active-connection slot', async (t)
   // (like a telnet client's IAC negotiation) and stays connected, leaving
   // unread data pending when the proxy rejects it.
   const blocked = await connect(listenPort, '127.0.0.1');
+  blocked.on('error', () => {});
   blocked.write('\xff\xfd\x18');
   t.after(() => blocked.destroy());
 
-  // Give the server time to reject the blocked client and release its slot
-  await new Promise((r) => setTimeout(r, 500));
+  // The observable effect of the rejection is the server closing the blocked
+  // socket; wait for that rather than a fixed sleep
+  await new Promise((resolve) => blocked.once('close', resolve));
+  // Small settle so the server-side 'close' handler (slot release) runs
+  await new Promise((r) => setTimeout(r, 100));
 
   // Allowed client: must get the only connection slot and reach the backend
   const allowed = await connect(listenPort, '::1');

--- a/tests/rejection-leak.test.js
+++ b/tests/rejection-leak.test.js
@@ -1,0 +1,120 @@
+/**
+ * Regression tests for connection-slot leak on rejected connections
+ * and for LOG_LEVEL=debug being honored.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const net = require('net');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn, spawnSync } = require('child_process');
+
+const REPO_ROOT = path.join(__dirname, '..');
+
+function listen(server, port, host) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, () => resolve(server.address().port));
+  });
+}
+
+function connect(port, host) {
+  return new Promise((resolve, reject) => {
+    const sock = net.createConnection({ port, host }, () => resolve(sock));
+    sock.once('error', reject);
+  });
+}
+
+// Waits for data (resolves) or close-without-data (resolves with null)
+function firstData(sock, timeoutMs) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(null), timeoutMs);
+    sock.once('data', (d) => {
+      clearTimeout(timer);
+      resolve(d);
+    });
+    sock.once('close', () => {
+      clearTimeout(timer);
+      resolve(null);
+    });
+  });
+}
+
+test('a rejected connection does not leak the active-connection slot', async (t) => {
+  // Fake backend so the test never touches a real BBS
+  const backend = net.createServer((sock) => {
+    sock.write('HELLO-BACKEND');
+  });
+  const backendPort = await listen(backend, 0, '127.0.0.1');
+
+  // Blocklist IPv4 loopback; the "allowed" client will come in via ::1
+  const blocklistPath = path.join(os.tmpdir(), `bbsfw-test-blocklist-${process.pid}.txt`);
+  fs.writeFileSync(blocklistPath, '127.0.0.1\n');
+
+  const listenPort = 20000 + Math.floor(Math.random() * 20000);
+  const child = spawn(process.execPath, ['server.js'], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      LISTEN_PORT: String(listenPort),
+      BACKEND_HOST: '127.0.0.1',
+      BACKEND_PORT: String(backendPort),
+      MAX_CONNECTIONS: '1',
+      BLOCKED_COUNTRIES: '',
+      RATE_LIMIT_ENABLED: 'false',
+      BLOCKLIST_PATH: blocklistPath,
+      SSH_ENABLED: 'false',
+      LOG_LEVEL: 'info',
+    },
+  });
+
+  t.after(() => {
+    child.kill('SIGKILL');
+    backend.close();
+    fs.rmSync(blocklistPath, { force: true });
+  });
+
+  await new Promise((resolve, reject) => {
+    let out = '';
+    const timer = setTimeout(() => reject(new Error(`server never started:\n${out}`)), 5000);
+    child.stdout.on('data', (d) => {
+      out += d.toString();
+      if (out.includes('listening on port')) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.on('exit', (code) => reject(new Error(`server exited (${code}):\n${out}`)));
+  });
+
+  // Blocked client: connects from the blocklisted IP, immediately sends bytes
+  // (like a telnet client's IAC negotiation) and stays connected, leaving
+  // unread data pending when the proxy rejects it.
+  const blocked = await connect(listenPort, '127.0.0.1');
+  blocked.write('\xff\xfd\x18');
+  t.after(() => blocked.destroy());
+
+  // Give the server time to reject the blocked client and release its slot
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Allowed client: must get the only connection slot and reach the backend
+  const allowed = await connect(listenPort, '::1');
+  t.after(() => allowed.destroy());
+  const data = await firstData(allowed, 2000);
+
+  assert.ok(
+    data && data.toString().includes('HELLO-BACKEND'),
+    'allowed connection should reach the backend; got no data — the rejected connection leaked the slot'
+  );
+});
+
+test('LOG_LEVEL=debug enables debug logging', () => {
+  const result = spawnSync(
+    process.execPath,
+    ['-e', "require('./logger').debug('dbg-probe-message')"],
+    { cwd: REPO_ROOT, env: { ...process.env, LOG_LEVEL: 'debug' }, encoding: 'utf8' }
+  );
+  assert.match(result.stdout, /dbg-probe-message/, 'debug message should be printed when LOG_LEVEL=debug');
+});


### PR DESCRIPTION
Rejected connections (IP filter, country block, undefined IP, max connections) called end() on sockets that never get a data handler. If the client had already sent bytes (telnet clients send IAC negotiation immediately), the socket never finished closing, 'close' never fired, and the activeConnections slot leaked until the connection timeout. With MAX_CONNECTIONS=1 a single rejection bricked the proxy for 5 minutes. Use destroy() in all rejection paths so 'close' is guaranteed, and add an error handler to the max-connections rejection so a socket error there cannot crash the process.

Also fix LOG_LEVEL=debug never taking effect: the debug level is 0, which is falsy, so `||` always fell back to info.

New feature: POST_SESSION_GRACE_MS holds new callers until a single-line backend (e.g. a BBS on real C64 hardware) has had time to recycle after the previous session ends. Bytes sent while held are buffered and forwarded in order once connected. Default 0 (disabled).

Adds a node:test suite (npm test) covering the leak, the log level, and the grace period.